### PR TITLE
feat: add daily ai digest automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# DeepSeek API
+DEEPSEEK_API_KEY=
+
+# GitHub Action 触发时间（北京时间小时，0-23）
+DISPATCH_HOUR_BEIJING=9
+
+# 邮件发送配置（示例为 Gmail，其他 SMTP 请按需修改）
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=465
+SMTP_SECURE=true
+SMTP_USER=you@gmail.com
+SMTP_PASS=app-specific-password
+MAIL_FROM=you@gmail.com
+MAIL_FROM_NAME=AI Daily Brief
+MAIL_TO=recipient@example.com

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next", "next/core-web-vitals"]
+}

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -1,0 +1,57 @@
+name: Daily AI Digest
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "立即执行一次"
+        default: "false"
+        required: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run daily script
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_SECURE: ${{ secrets.SMTP_SECURE }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          MAIL_FROM: ${{ secrets.MAIL_FROM }}
+          MAIL_FROM_NAME: ${{ secrets.MAIL_FROM_NAME }}
+          MAIL_TO: ${{ secrets.MAIL_TO }}
+          DISPATCH_HOUR_BEIJING: ${{ vars.DISPATCH_HOUR_BEIJING }}
+          FORCE_DISPATCH: ${{ github.event.inputs.force || 'false' }}
+        run: npm run daily
+
+      - name: Commit updated brief
+        if: success()
+        run: |
+          if [[ -n $(git status --porcelain data/latest.json) ]]; then
+            git config user.name "github-actions"
+            git config user.email "github-actions@github.com"
+            git add data/latest.json
+            git commit -m "chore: update daily ai digest"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+out
+.env
+.env.local
+.env.production
+.env.development
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
-# daily_ai_news_feed
-auto get daily AI tech news and comment on the news
+# 每日 AI 科技热点速递
+
+一个完全免费的全栈方案：
+
+- Next.js Web UI（部署到 Vercel）展示每日热点、提问与 DeepSeek 点评；
+- GitHub Actions 每天定时获取 10 条最新 AI 科技热点、生成问题并调用 DeepSeek-V3.1 生成洞察；
+- Nodemailer 通过任意免费 SMTP（如 Gmail、QQ 邮箱）发送邮件。
+
+## 功能概览
+
+| 功能 | 说明 |
+| --- | --- |
+| 热点来源 | Hacker News (Algolia API) 按当天热度筛选 AI 相关资讯 |
+| 智能点评 | 调用 [硅基流动 DeepSeek-V3.1 Chat Completions](https://docs.siliconflow.cn/cn/api-reference/chat-completions/chat-completions) |
+| 提问生成 | 针对每条新闻自动生成延伸问题（多模版随机） |
+| 邮件发送 | Markdown 风格 HTML + 纯文本双格式，自动发至指定邮箱 |
+| 配置时间 | 通过 `DISPATCH_HOUR_BEIJING` 指定北京时间小时 |
+| 强制执行 | 手动触发 GitHub Workflow 时可勾选 force 立即运行 |
+
+## 快速开始
+
+### 1. 本地开发
+
+```bash
+npm install
+npm run dev
+```
+
+浏览器访问 `http://localhost:3000` 查看界面。默认 `data/latest.json` 为空，首次 GitHub Action 运行后会自动填充。
+
+### 2. 必要配置
+
+| 变量 | 作用 | 建议存放 |
+| --- | --- | --- |
+| `DEEPSEEK_API_KEY` | 硅基流动 DeepSeek API Key | GitHub Repository Secrets |
+| `SMTP_HOST` `SMTP_PORT` `SMTP_SECURE` `SMTP_USER` `SMTP_PASS` | SMTP 服务器信息 | GitHub Repository Secrets |
+| `MAIL_FROM` / `MAIL_FROM_NAME` | 邮件发件信息 | GitHub Repository Secrets |
+| `MAIL_TO` | 收件邮箱 | GitHub Repository Secrets |
+| `DISPATCH_HOUR_BEIJING` | 每日推送时间（北京时间小时，0-23） | GitHub Repository Variables |
+
+> 可以参考 `.env.example` 在本地调试，正式运行请将敏感信息写入 GitHub Secrets。
+
+### 3. GitHub Action 调度
+
+- Workflow 文件：`.github/workflows/daily.yml`
+- 默认每小时运行一次，脚本会判断当前北京时间是否等于 `DISPATCH_HOUR_BEIJING`，只有在匹配时才真正执行（避免复杂的时区换算）。
+- 如需立刻运行，可在 GitHub Actions 页面手动触发 `workflow_dispatch` 并将 `force` 设为 `true`。
+
+### 4. 邮件发送
+
+脚本使用 Nodemailer，兼容任意支持 SMTP 的免费邮箱服务。
+
+#### Gmail 示例
+1. 开启两步验证并创建 **应用专用密码**；
+2. `SMTP_HOST=smtp.gmail.com`，`SMTP_PORT=465`，`SMTP_SECURE=true`；
+3. `SMTP_USER`/`MAIL_FROM` 为你的 Gmail 地址，`SMTP_PASS` 使用应用专用密码。
+
+#### QQ 邮箱示例
+1. 在设置中开启“POP3/SMTP 服务”；
+2. `SMTP_HOST=smtp.qq.com`，`SMTP_PORT=465`，`SMTP_SECURE=true`；
+3. `SMTP_USER`/`MAIL_FROM` 使用 QQ 邮箱，`SMTP_PASS` 使用授权码。
+
+### 5. Vercel 部署
+
+1. 在 Vercel 导入此仓库；
+2. 构建命令使用 `npm run build`，输出目录自动为 `.next`；
+3. 由于 `data/latest.json` 会被 GitHub Action 更新并提交，新部署会自动包含最新数据；
+4. 需要在 Vercel 环境变量中同步配置（至少 `NEXT_PUBLIC_SITE_TITLE` 非必需，本项目所有 API 调用均在 GitHub Action 内完成，线上仅负责展示）。
+
+### 6. 常见问题
+
+- **为什么页面没有数据？**：确认 GitHub Action 成功运行，并检查 `data/latest.json` 是否被最新提交更新。
+- **DeepSeek 调用失败**：确认 API Key 正确、GitHub Secrets 已配置；必要时在 Workflow 日志中查看错误信息。
+- **邮件未收到**：检查 SMTP 授权是否正确、是否被服务商拦截，可先在本地运行 `FORCE_DISPATCH=true npm run daily` 进行调试。
+
+### 7. 用户需额外配置的最少项目
+
+1. 在 GitHub 仓库中添加 Secrets：`DEEPSEEK_API_KEY`、`SMTP_HOST`、`SMTP_PORT`、`SMTP_SECURE`、`SMTP_USER`、`SMTP_PASS`、`MAIL_FROM`、`MAIL_TO`（可选 `MAIL_FROM_NAME`）。
+2. 在 GitHub 仓库中添加 Repository Variable：`DISPATCH_HOUR_BEIJING`（例如 `9` 代表每天上午九点）。
+3. 在 Vercel 中设置对应的环境变量（用于本地调试或未来扩展）。
+
+完成以上步骤后，你即可享受每日自动生成的 AI 热点洞察，无需手动操作。

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,65 @@
+:root {
+  color-scheme: dark;
+}
+
+body {
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+a {
+  color: #60a5fa;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.section-card {
+  background: linear-gradient(145deg, rgba(30, 41, 59, 0.9), rgba(15, 23, 42, 0.9));
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 10px 40px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(10px);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  background-color: rgba(96, 165, 250, 0.1);
+  color: #bfdbfe;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.question {
+  font-weight: 600;
+  margin-top: 1rem;
+  margin-bottom: 0.75rem;
+  color: #f1f5f9;
+}
+
+.answer {
+  line-height: 1.7;
+  color: #cbd5f5;
+}
+
+.timestamp {
+  color: #94a3b8;
+  font-size: 0.85rem;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "每日AI热点速递",
+  description: "每天自动汇总AI科技热点、提问并生成点评"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="zh-CN">
+      <body className="min-h-screen bg-slate-950 text-slate-100">
+        <main className="mx-auto max-w-4xl px-4 py-10">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,81 @@
+import newsData from "../data/latest.json";
+
+interface NewsItem {
+  id: string;
+  title: string;
+  url: string;
+  source?: string;
+  question: string;
+  answer: string;
+}
+
+const formatTimestamp = (isoString: string | null) => {
+  if (!isoString) {
+    return "尚未生成，请稍后再来";
+  }
+
+  const date = new Date(isoString);
+  return new Intl.DateTimeFormat("zh-CN", {
+    timeZone: "Asia/Shanghai",
+    dateStyle: "full",
+    timeStyle: "short"
+  }).format(date);
+};
+
+export default function HomePage() {
+  const items = (newsData.items as NewsItem[]) ?? [];
+  const generatedAt = newsData.generatedAt as string | null;
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <span className="badge">AI 热点 · 每日自动生成</span>
+        <h1 className="text-3xl font-semibold text-slate-50 md:text-4xl">
+          今日 AI 科技热点速览
+        </h1>
+        <p className="timestamp">最近更新：{formatTimestamp(generatedAt)}</p>
+        <p className="text-slate-300">
+          我们会每天从公开渠道选出十条 AI 科技热点，针对每条热点提出延伸问题，并调用
+          DeepSeek 模型生成洞察点评。数据也会通过邮件同步发送给你。
+        </p>
+      </header>
+
+      {items.length === 0 ? (
+        <section className="section-card text-slate-300">
+          <h2 className="text-xl font-semibold text-slate-100">还没有内容</h2>
+          <p className="mt-2">
+            等待 GitHub Action 首次运行后，这里会展示每日热点、问题以及 DeepSeek 的分析结果。
+          </p>
+        </section>
+      ) : (
+        <section className="card-grid">
+          {items.map((item, index) => (
+            <article key={item.id ?? index} className="section-card">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h2 className="text-xl font-semibold text-slate-50">
+                    <a href={item.url} target="_blank" rel="noreferrer">
+                      {item.title}
+                    </a>
+                  </h2>
+                  {item.source ? (
+                    <p className="mt-1 text-sm text-slate-400">来源：{item.source}</p>
+                  ) : null}
+                </div>
+                <span className="badge">#{index + 1}</span>
+              </div>
+              <p className="question">Q：{item.question}</p>
+              <p className="answer whitespace-pre-wrap">A：{item.answer}</p>
+            </article>
+          ))}
+        </section>
+      )}
+
+      <footer className="section-card text-sm text-slate-400">
+        <p>
+          部署在 Vercel · 数据每日由 GitHub Action 调度。你可以在仓库的 README 中找到配置说明，修改推送时间或邮件地址。
+        </p>
+      </footer>
+    </div>
+  );
+}

--- a/data/latest.json
+++ b/data/latest.json
@@ -1,0 +1,4 @@
+{
+  "generatedAt": null,
+  "items": []
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "daily_ai_news_feed",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "daily": "node scripts/runDaily.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "next": "14.2.4",
+    "nodemailer": "^6.9.13",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.4",
+    "typescript": "5.4.5"
+  }
+}

--- a/scripts/runDaily.js
+++ b/scripts/runDaily.js
@@ -1,0 +1,300 @@
+const fs = require("fs");
+const path = require("path");
+const nodemailer = require("nodemailer");
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+const DISPATCH_HOUR = Number.parseInt(process.env.DISPATCH_HOUR_BEIJING ?? "9", 10);
+const ITEMS_LIMIT = 10;
+
+const nowInBeijing = () =>
+  new Date(
+    new Date().toLocaleString("en-US", {
+      timeZone: "Asia/Shanghai"
+    })
+  );
+
+const shouldRunNow = () => {
+  if (process.env.FORCE_DISPATCH === "true") {
+    return true;
+  }
+
+  const beijing = nowInBeijing();
+  const targetHour = Number.isNaN(DISPATCH_HOUR) ? 9 : DISPATCH_HOUR;
+  return beijing.getHours() === targetHour;
+};
+
+const getStartOfTodayTimestamp = () => {
+  const beijing = nowInBeijing();
+  beijing.setHours(0, 0, 0, 0);
+  return Math.floor(beijing.getTime() / 1000);
+};
+
+const pickQuestion = (title, source) => {
+  const templates = [
+    `如何看待“${title}”？这条消息背后的趋势是什么？`,
+    `从行业角度看，“${title}” 对未来半年的 AI 布局意味着什么？`,
+    `如果你是投资人，会如何评价“${title}” 的潜在价值？`,
+    `站在普通开发者角度，${title} 带来哪些值得关注的机会？`,
+    `这条来自 ${source ?? "业内"} 的动态“${title}” 会如何影响国内外生态？`
+  ];
+
+  return templates[Math.floor(Math.random() * templates.length)];
+};
+
+const fetchDailyNews = async () => {
+  const startTimestamp = getStartOfTodayTimestamp();
+  const endpoint = new URL("https://hn.algolia.com/api/v1/search");
+  endpoint.searchParams.set("query", "AI");
+  endpoint.searchParams.set("tags", "story");
+  endpoint.searchParams.set("numericFilters", `created_at_i>${startTimestamp}`);
+  endpoint.searchParams.set("hitsPerPage", String(ITEMS_LIMIT * 2));
+
+  const response = await fetch(endpoint.href);
+  if (!response.ok) {
+    throw new Error(`无法获取新闻：${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+  const hits = Array.isArray(payload.hits) ? payload.hits : [];
+
+  const items = hits
+    .filter((item) => item?.title)
+    .map((item) => {
+      const url = item.url || `https://news.ycombinator.com/item?id=${item.objectID}`;
+      let source;
+      try {
+        source = new URL(url).hostname.replace(/^www\./, "");
+      } catch (error) {
+        source = "news.ycombinator.com";
+      }
+
+      return {
+        id: item.objectID,
+        title: item.title,
+        url,
+        source,
+        points: item.points ?? 0,
+        text: item.story_text || item.comment_text || ""
+      };
+    })
+    .sort((a, b) => (b.points ?? 0) - (a.points ?? 0))
+    .slice(0, ITEMS_LIMIT);
+
+  return items;
+};
+
+const callDeepSeek = async ({ title, question, url, text, source }) => {
+  const apiKey = process.env.DEEPSEEK_API_KEY;
+  if (!apiKey) {
+    console.warn("未配置 DEEPSEEK_API_KEY，使用占位回答。");
+    return "（未配置 DeepSeek API Key，无法生成智能点评。请在仓库 Secrets 中设置 DEEPSEEK_API_KEY。）";
+  }
+
+  const prompt = [
+    `请基于以下信息输出一段 150-200 字的中文分析，语气专业、可读性强：`,
+    `标题：${title}`,
+    `来源：${source ?? "未知"}`,
+    url ? `链接：${url}` : null,
+    text ? `原文摘要：${text}` : null,
+    `提问：${question}`,
+    `请提供结构化的见解（包括现状、意义和潜在风险），不需要重复问题。`
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const response = await fetch("https://api.siliconflow.cn/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: "deepseek-ai/DeepSeek-V3.1",
+      messages: [
+        {
+          role: "system",
+          content: "你是一名关注人工智能行业的科技分析师，需要给出简洁、有洞察力的中文解读。"
+        },
+        {
+          role: "user",
+          content: prompt
+        }
+      ],
+      temperature: 0.7,
+      max_tokens: 600
+    })
+  });
+
+  if (!response.ok) {
+    const errText = await response.text();
+    throw new Error(`调用 DeepSeek 失败：${response.status} ${errText}`);
+  }
+
+  const data = await response.json();
+  const answer = data?.choices?.[0]?.message?.content?.trim();
+  if (!answer) {
+    throw new Error("DeepSeek 返回数据为空");
+  }
+  return answer;
+};
+
+const buildEmailContent = (items, generatedAtISO) => {
+  const formattedDate = new Intl.DateTimeFormat("zh-CN", {
+    timeZone: "Asia/Shanghai",
+    dateStyle: "full",
+    timeStyle: "short"
+  }).format(new Date(generatedAtISO));
+
+  const htmlItems = items
+    .map(
+      (item, index) => `
+        <tr>
+          <td style="padding:16px;border-bottom:1px solid #e2e8f0;">
+            <h3 style="margin:0 0 8px 0;font-size:16px;color:#0f172a;">${index + 1}. <a href="${item.url}" style="color:#2563eb;text-decoration:none;">${item.title}</a></h3>
+            <p style="margin:0 0 8px 0;color:#475569;font-size:13px;">来源：${item.source ?? "未知"}</p>
+            <p style="margin:0 0 12px 0;font-weight:600;color:#0f172a;">Q：${item.question}</p>
+            <p style="margin:0;color:#334155;line-height:1.6;white-space:pre-wrap;">A：${item.answer}</p>
+          </td>
+        </tr>`
+    )
+    .join("\n");
+
+  const html = `
+    <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;background:#f8fafc;padding:24px;color:#0f172a;">
+      <h2 style="margin:0 0 16px 0;">今日 AI 科技热点速递</h2>
+      <p style="margin:0 0 24px 0;color:#475569;">生成时间（北京时间）：${formattedDate}</p>
+      <table style="border-collapse:collapse;width:100%;background:#fff;border-radius:16px;overflow:hidden;box-shadow:0 10px 25px rgba(15,23,42,0.1);">
+        <tbody>
+          ${htmlItems}
+        </tbody>
+      </table>
+      <p style="margin-top:24px;color:#64748b;font-size:12px;">自动生成 · GitHub Action + DeepSeek 提供支持</p>
+    </div>
+  `;
+
+  const textItems = items
+    .map((item, index) => {
+      return [
+        `${index + 1}. ${item.title}`,
+        `来源：${item.source ?? "未知"}`,
+        `链接：${item.url}`,
+        `Q：${item.question}`,
+        `A：${item.answer}`,
+        ""
+      ].join("\n");
+    })
+    .join("\n");
+
+  const text = `今日 AI 科技热点速递\n生成时间（北京时间）：${formattedDate}\n\n${textItems}`;
+
+  return { html, text };
+};
+
+const sendEmail = async (items, generatedAtISO) => {
+  const requiredEnv = ["SMTP_HOST", "SMTP_PORT", "SMTP_USER", "SMTP_PASS", "MAIL_TO"];
+  const missing = requiredEnv.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    console.warn(`缺少邮件配置 ${missing.join(", ")}，跳过发送邮件。`);
+    return;
+  }
+
+  const port = Number.parseInt(process.env.SMTP_PORT, 10);
+  const secure = process.env.SMTP_SECURE ? process.env.SMTP_SECURE === "true" : port === 465;
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port,
+    secure,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS
+    }
+  });
+
+  const fromName = process.env.MAIL_FROM_NAME || "AI Daily";
+  const fromAddress = process.env.MAIL_FROM || process.env.SMTP_USER;
+  const toAddress = process.env.MAIL_TO;
+
+  const { html, text } = buildEmailContent(items, generatedAtISO);
+
+  await transporter.sendMail({
+    from: `${fromName} <${fromAddress}>`,
+    to: toAddress,
+    subject: `今日 AI 热点 (${new Date(generatedAtISO).toLocaleDateString("zh-CN", { timeZone: "Asia/Shanghai" })})`,
+    text,
+    html
+  });
+
+  console.log(`已发送邮件至 ${toAddress}`);
+};
+
+const writeDataFile = (items, generatedAtISO) => {
+  const output = {
+    generatedAt: generatedAtISO,
+    items: items.map(({ id, title, url, source, question, answer }) => ({
+      id,
+      title,
+      url,
+      source,
+      question,
+      answer
+    }))
+  };
+
+  const targetPath = path.join(process.cwd(), "data", "latest.json");
+  fs.writeFileSync(targetPath, JSON.stringify(output, null, 2), "utf8");
+  console.log(`已写入 ${targetPath}`);
+};
+
+const main = async () => {
+  if (!shouldRunNow()) {
+    console.log(
+      `当前北京时间 ${nowInBeijing().toISOString()} 不在设定的触发小时 (${DISPATCH_HOUR}). 设置 FORCE_DISPATCH=true 可强制执行。`
+    );
+    return;
+  }
+
+  console.log("开始获取今日 AI 热点...");
+  const rawItems = await fetchDailyNews();
+  console.log(`获取到 ${rawItems.length} 条候选热点，开始生成点评。`);
+
+  const itemsWithInsights = [];
+  for (const item of rawItems) {
+    const question = pickQuestion(item.title, item.source);
+    try {
+      const answer = await callDeepSeek({
+        title: item.title,
+        url: item.url,
+        text: item.text,
+        question,
+        source: item.source
+      });
+      itemsWithInsights.push({ ...item, question, answer });
+    } catch (error) {
+      console.error(`生成点评失败 (${item.title})`, error);
+      itemsWithInsights.push({
+        ...item,
+        question,
+        answer: "（调用 DeepSeek 失败，已记录日志，请稍后重试）"
+      });
+    }
+  }
+
+  const generatedAtISO = new Date().toISOString();
+  writeDataFile(itemsWithInsights, generatedAtISO);
+
+  try {
+    await sendEmail(itemsWithInsights, generatedAtISO);
+  } catch (error) {
+    console.error("发送邮件失败", error);
+  }
+
+  console.log("任务完成");
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.d.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build a Next.js front end that reads the generated daily digest JSON and renders the AI news, questions, and DeepSeek answers
- add a Node.js automation script plus GitHub Actions workflow to fetch daily AI headlines, ask DeepSeek for commentary, save the digest, and email the report
- document environment variables, deployment, and scheduling steps so the tool can run with free services and minimal manual setup

## Testing
- not run (npm install blocked by outbound network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68cd277561408325baa83fabf0c80155