### PR TITLE
Add noopener noreferrer to news title links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,7 +55,11 @@ export default function HomePage() {
               <div className="flex items-start justify-between gap-4">
                 <div>
                   <h2 className="text-xl font-semibold text-slate-50">
-                    <a href={item.url} target="_blank" rel="noreferrer">
+                    <a
+                      href={item.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       {item.title}
                     </a>
                   </h2>


### PR DESCRIPTION
## Summary
- update the external news title anchor so it uses rel="noopener noreferrer" for improved security

## Testing
- npm run lint *(fails: npm cannot install @types/node from registry due to 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68cec4be75b8832592b36f6aec54d637